### PR TITLE
fix: TeleportListener#onPlayerDamage

### DIFF
--- a/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
+++ b/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
@@ -88,10 +88,6 @@ final class TeleportListener implements Listener {
             return;
         }
 
-        if (event.isCancelled()) {
-            return;
-        }
-
         TeleportHandler handler = this.manager.getTeleportHandler();
         TeleportTask task = this.tasks.get(player);
         TeleportContext context = task.createContext(false);

--- a/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
+++ b/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
@@ -88,6 +88,10 @@ final class TeleportListener implements Listener {
             return;
         }
 
+        if (event.isCancelled()) {
+            return;
+        }
+
         TeleportHandler handler = this.manager.getTeleportHandler();
         TeleportTask task = this.tasks.get(player);
         TeleportContext context = task.createContext(false);

--- a/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
+++ b/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -77,7 +76,7 @@ final class TeleportListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(ignoreCancelled = true)
     public void onPlayerDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player)) {
             return;

--- a/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
+++ b/src/main/java/co/crystaldev/alpinecore/framework/teleport/TeleportListener.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -76,7 +77,7 @@ final class TeleportListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player)) {
             return;


### PR DESCRIPTION
The `TeleportListener#onPlayerDamage` method does not check if the event was cancelled. This causes issues with other plugins which cancel this event while a player is teleporting.
- Changed EventHandler to priority to monitor
- Added check to see if event is cancelled